### PR TITLE
Adding environment specific configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,9 @@
 use Mix.Config
 
-config :exvcr,
-  vcr_cassette_library_dir: "fixtures/vcr_cassettes",
-  custom_cassette_library_dir: "fixtures/custom_cassettes"
+case Mix.env do
+  :test ->
+    config :exvcr,
+      vcr_cassette_library_dir: "fixtures/vcr_cassettes",
+      custom_cassette_library_dir: "fixtures/custom_cassettes"
+  _ -> {}
+end


### PR DESCRIPTION
Problem:

Was getting warnings about missing exvcr as a dependency when using the package.

Solution:

Moved exvcr config to only run in the test env, since that's where the dependency is.